### PR TITLE
sequelize 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - 4
   - 6
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 
 node_js:
-  - "0.10"
-  - "0.12"
-  - "iojs"
+  - 6
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- Support for Sequelize 4
+
+### Removed
+- Support for Sequelize 2 & 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-All notable changes to this project will be documented in this file.
-
-## [Unreleased]
-### Added
-- Support for Sequelize 4
-
-### Removed
-- Support for Sequelize 2 & 3

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,14 +4,14 @@ var Sequelize = require('sequelize')
   , init;
 
 init = function(target) {
-  if (target instanceof Sequelize.Model) {
-    var $get = target.Instance.prototype.get;
+  if (target.prototype instanceof Sequelize.Model) {
+    var $get = target.prototype.get;
 
     Object.keys(target.rawAttributes).forEach(function (attr) {
       if (target.rawAttributes[attr].roles !== undefined) {
         if (target.rawAttributes[attr].roles === false) {
           target.rawAttributes[attr].roles = {};
-          return; 
+          return;
         }
 
         Object.keys(target.rawAttributes[attr].roles).forEach(function (role) {
@@ -33,7 +33,7 @@ init = function(target) {
       }
     });
 
-    target.Instance.prototype.get = function(key, options) {
+    target.prototype.get = function(key, options) {
       if (typeof key === "object" && !options) {
         options = key;
         key = undefined;
@@ -57,12 +57,12 @@ init = function(target) {
 
       var values = $get.call(this, options)
         , response = {};
-        
+
       Object.keys(values).forEach(function (key) {
         var attr = target.rawAttributes[key];
 
         var val = values[key];
-        if(!attr && val instanceof Sequelize.Instance) {
+        if(!attr && val instanceof Sequelize.Model) {
           response[key] = val.get.call(val, options);
         }
         else if (!attr || !attr.roles || attr.roles && attr.roles[options.role] && attr.roles[options.role].get) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "istanbul": "^0.3.7",
     "jshint": "^2.6.3",
     "mocha": "^2.2.1",
-    "sequelize": "^2.1.1",
+    "sequelize": "^4.14.0",
     "sqlite3": "^3.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "mocha": "^2.2.1",
     "sequelize": "^4.14.0",
     "sqlite3": "^3.0.5"
+  },
+  "peerDependencies": {
+    "sequelize": "4.x"
   }
 }


### PR DESCRIPTION
This PR is an adjustment to the breaking changes introduced in sequelize v4.
It is not backward compatible with previous versions of sequelize and should be released with a new major version.
If it is accepted, I will submit another one on [pumpupapp/ssacl](https://github.com/pumpupapp/ssacl) referencing the new release and fixing sequelize v4 compatibility issues.

Tested with sequelize 4.14.0.